### PR TITLE
fix: mask telegram message

### DIFF
--- a/.github/workflows/run-action.yml
+++ b/.github/workflows/run-action.yml
@@ -60,7 +60,8 @@ jobs:
 
     - name: Run script
       run: |
-        node index.js $(jq -r '.inputs.json_msg' ${GITHUB_EVENT_PATH})
+        jq -r -c '.inputs.json_msg' ${GITHUB_EVENT_PATH} > message.json
+        node index.js --jsonPath message.json
       env:
         TDG_USER: ${{ secrets.TDG_USER }}
         TDG_PASSWORD: ${{ secrets.TDG_PASSWORD }}

--- a/bin/telegram-tester.js
+++ b/bin/telegram-tester.js
@@ -8,7 +8,7 @@ async function echoChatId (env) {
   const bot = new Telegraf(env.TELEGRAM_BOT_TOKEN)
 
   bot.use(async ctx => {
-    await botBrain([JSON.stringify(ctx.update)], process.env)
+    await botBrain(JSON.stringify(ctx.update), process.env)
   })
 
   bot.catch(async (err, ctx) => {

--- a/index.js
+++ b/index.js
@@ -1,13 +1,21 @@
 'use strict'
 
+const fs = require('node:fs')
+const { parseArgs } = require('node:util')
+
 // ! These commands map the Telegram command (configured in BotFather)
 const mappedCommands = {
   '/magazine': require('./actions/download-tdg'),
   '/chatid': require('./actions/telegram-notification'),
 }
 
-async function run (args, env) {
-  const telegramMsg = JSON.parse(args[0])
+/**
+ *
+ * @param {string} jsonString
+ * @param {import('node:process').Env} env
+ */
+async function run (jsonString, env) {
+  const telegramMsg = JSON.parse(jsonString)
 
   const commandName = telegramMsg?.message?.text?.startsWith('/') && telegramMsg.message.text.split(' ')[0]
   const actionToDo = mappedCommands[commandName]
@@ -16,15 +24,26 @@ async function run (args, env) {
   }
 
   console.log(`Executing command: ${commandName}`)
-  const params = actionToDo.buildOptions(telegramMsg, env)
-  await actionToDo.executeFlow(params)
+  const opts = actionToDo.buildOptions(telegramMsg, env)
+  await actionToDo.executeFlow(opts)
 }
 
 if (require.main === module) {
   // Production mode: run as script
-  run(process.argv.slice(2), process.env)
+  const options = {
+    jsonPath: {
+      type: 'strict',
+    },
+  }
+  const { values } = parseArgs({ options })
+  const jsonString = fs.readFileSync(values.jsonPath, 'utf8')
+
+  run(jsonString, process.env)
     .then(() => console.log('Done'))
-    .catch(error => console.error('Error:', error))
+    .catch(error => {
+      console.error('Error:', error)
+      process.exit(1)
+    })
 } else {
   // Test mode: run as module
   module.exports = run

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ if (require.main === module) {
   // Production mode: run as script
   const options = {
     jsonPath: {
-      type: 'strict',
+      type: 'string',
     },
   }
   const { values } = parseArgs({ options })


### PR DESCRIPTION
We can't propagate the GHA via an arg to the `index.js`, so creating an intermediate file can hide the message from the GHA logs